### PR TITLE
Change behaviour for PRs

### DIFF
--- a/chains/v1/chains.json
+++ b/chains/v1/chains.json
@@ -198,12 +198,12 @@
                 "name": "Parity node"
             },
             {
-                "url": "wss://westend.api.onfinality.io/public-ws",
-                "name": "OnFinality node"
-            },
-            {
                 "url": "wss://westend-rpc.dwellir.com",
                 "name": "Dwellir node"
+            },
+            {
+                "url": "wss://westend.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "assets": [
@@ -381,22 +381,13 @@
         "chainId": "0xbaf5aabe40646d11f0ee8abbdc64f4a4b7674925cba08e4a05ff9ebed6e2126b",
         "parentId": "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/chains/Karura.svg",
+        "options": [
+            "multisig"
+        ],
         "nodes": [
             {
-                "url": "wss://karura-rpc-0.aca-api.network",
-                "name": "Acala Foundation 0 node"
-            },
-            {
-                "url": "wss://karura-rpc-1.aca-api.network",
-                "name": "Acala Foundation 1 node"
-            },
-            {
-                "url": "wss://karura-rpc-2.aca-api.network/ws",
-                "name": "Acala Foundation 2 node"
-            },
-            {
-                "url": "wss://karura-rpc-3.aca-api.network/ws",
-                "name": "Acala Foundation 3 node"
+                "url": "wss://karura.api.onfinality.io/public-ws",
+                "name": "Onfinality node"
             }
         ],
         "assets": [
@@ -1397,10 +1388,6 @@
         ],
         "nodes": [
             {
-                "url": "wss://fullnode.altair.centrifuge.io",
-                "name": "Centrifuge node"
-            },
-            {
                 "url": "wss://altair.api.onfinality.io/public-ws",
                 "name": "OnFinality node"
             }
@@ -1907,6 +1894,10 @@
         ],
         "nodes": [
             {
+                "url": "wss://kilt-rpc.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
                 "url": "wss://spiritnet.kilt.io/",
                 "name": "KILT Protocol node"
             },
@@ -2033,7 +2024,7 @@
                 "typeExtras": {
                     "assetId": "15"
                 },
-                "name": "Should be included in scripts/data/assetsNameMap"
+                "name": "DAI-Karura"
             },
             {
                 "assetId": 6,
@@ -2045,7 +2036,7 @@
                 "typeExtras": {
                     "assetId": "16"
                 },
-                "name": "Should be included in scripts/data/assetsNameMap"
+                "name": "USDC-Karura"
             }
         ],
         "explorers": [
@@ -3425,6 +3416,10 @@
             {
                 "url": "wss://picasso-rpc.composable.finance",
                 "name": "Composable node"
+            },
+            {
+                "url": "wss://rpc.composablenodes.tech",
+                "name": "Composable node"
             }
         ],
         "assets": [
@@ -3717,6 +3712,9 @@
         "chainId": "0xcdedc8eadbfa209d3f207bba541e57c3c58a667b05a2e1d1e86353c9000758da",
         "parentId": "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/chains/Integritee.svg",
+        "options": [
+            "multisig"
+        ],
         "nodes": [
             {
                 "url": "wss://kusama.api.integritee.network",
@@ -4689,10 +4687,6 @@
             {
                 "url": "wss://rpc.composable.finance",
                 "name": "Composable node"
-            },
-            {
-                "url": "wss://composable.api.onfinality.io/public-ws",
-                "name": "Onfinality node"
             }
         ],
         "assets": [
@@ -4826,6 +4820,42 @@
                     "assetId": "3496813586714279103986568049643838918"
                 },
                 "name": "USD Tether"
+            },
+            {
+                "assetId": 3,
+                "symbol": "ASTR",
+                "precision": 12,
+                "type": "statemine",
+                "priceId": "astar",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Astar_(ASTR).svg",
+                "typeExtras": {
+                    "assetId": "222121451965151777636299756141619631150"
+                },
+                "name": "Astar"
+            },
+            {
+                "assetId": 4,
+                "symbol": "PHA",
+                "precision": 12,
+                "type": "statemine",
+                "priceId": "pha",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Phala_(PHA).svg",
+                "typeExtras": {
+                    "assetId": "193492391581201937291053139015355410612"
+                },
+                "name": "Phala"
+            },
+            {
+                "assetId": 5,
+                "symbol": "iBTC",
+                "precision": 12,
+                "type": "statemine",
+                "priceId": "bitcoin",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/iBTC.svg",
+                "typeExtras": {
+                    "assetId": "226557799181424065994173367616174607641"
+                },
+                "name": "Interlay Bitcoin"
             }
         ],
         "explorers": [
@@ -5615,49 +5645,14 @@
         }
     },
     {
-        "name": "Kylin",
-        "addressPrefix": 42,
-        "chainId": "0xf2584690455deda322214e97edfffaf4c1233b6e4625e39478496b3e2f5a44c5",
-        "parentId": "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
-        "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/chains/Kylin.svg",
-        "nodes": [
-            {
-                "url": "wss://polkadot.kylin-node.co.uk",
-                "name": "Kylin node"
-            }
-        ],
-        "assets": [
-            {
-                "assetId": 0,
-                "symbol": "KYL",
-                "precision": 18,
-                "priceId": "kylin-network",
-                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Kylin_(KYL).svg",
-                "name": "Kylin"
-            }
-        ],
-        "explorers": [
-            {
-                "name": "Polkaholic",
-                "account": "https://polkaholic.io/account/{address}",
-                "extrinsic": "https://polkaholic.io/tx/{hash}"
-            }
-        ],
-        "externalApi": {
-            "history": [
-                {
-                    "type": "subquery",
-                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-kylin"
-                }
-            ]
-        }
-    },
-    {
         "name": "Kapex",
         "addressPrefix": 2007,
         "chainId": "0x7838c3c774e887c0a53bcba9e64f702361a1a852d5550b86b58cd73827fa1e1e",
         "parentId": "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/chains/Totem.svg",
+        "options": [
+            "multisig"
+        ],
         "nodes": [
             {
                 "url": "wss://kapex-rpc.dwellir.com",
@@ -5804,6 +5799,14 @@
             "multisig"
         ],
         "nodes": [
+            {
+                "url": "wss://xxnetwork-rpc.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc.xx.network",
+                "name": "xx Foundation node"
+            },
             {
                 "url": "wss://rpc-hetzner.xx.network",
                 "name": "xx Foundation node"
@@ -6092,6 +6095,14 @@
             "multisig"
         ],
         "nodes": [
+            {
+                "url": "wss://rpc.3dpscan.io",
+                "name": "3DPass node"
+            },
+            {
+                "url": "wss://rpc.3dpass.org",
+                "name": "3DPass node"
+            },
             {
                 "url": "wss://rpc2.3dpass.org",
                 "name": "3DPass node"
@@ -6480,5 +6491,27 @@
                 }
             ]
         }
+    },
+    {
+        "name": "Watr",
+        "addressPrefix": 19,
+        "chainId": "0x161db6cdc5896fe55ef12b4778fe78dd65d7af43f65c601786b88d7a93ebc58a",
+        "parentId": "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
+        "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/chains/Watr.svg",
+        "nodes": [
+            {
+                "url": "wss://watr-rpc.watr-api.network",
+                "name": "EWX node"
+            }
+        ],
+        "assets": [
+            {
+                "assetId": 0,
+                "symbol": "WATR",
+                "precision": 18,
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Watr.svg",
+                "name": "WATR token"
+            }
+        ]
     }
 ]

--- a/chains/v1/chains.json
+++ b/chains/v1/chains.json
@@ -83,7 +83,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-polkadot"
                 }
             ]
-        }
+        },
+        "specName": "polkadot"
     },
     {
         "name": "Kusama",
@@ -173,7 +174,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-kusama"
                 }
             ]
-        }
+        },
+        "specName": "kusama"
     },
     {
         "name": "Westend",
@@ -794,7 +796,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-karura"
                 }
             ]
-        }
+        },
+        "specName": "karura"
     },
     {
         "name": "Shiden",
@@ -996,7 +999,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-shiden"
                 }
             ]
-        }
+        },
+        "specName": "shiden"
     },
     {
         "name": "Bifrost Kusama",
@@ -1246,7 +1250,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-bifrost"
                 }
             ]
-        }
+        },
+        "specName": "bifrost"
     },
     {
         "name": "Basilisk",
@@ -1375,7 +1380,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-basilisk"
                 }
             ]
-        }
+        },
+        "specName": "basilisk"
     },
     {
         "name": "Altair",
@@ -1426,7 +1432,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-altair"
                 }
             ]
-        }
+        },
+        "specName": "altair"
     },
     {
         "name": "Parallel Heiko",
@@ -1603,7 +1610,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-parallel-heiko"
                 }
             ]
-        }
+        },
+        "specName": "heiko"
     },
     {
         "name": "Edgeware",
@@ -1881,7 +1889,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-khala"
                 }
             ]
-        }
+        },
+        "specName": "khala"
     },
     {
         "name": "KILT",
@@ -1940,7 +1949,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-kilt"
                 }
             ]
-        }
+        },
+        "specName": "kilt-spiritnet"
     },
     {
         "name": "Calamari",
@@ -2069,7 +2079,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-calamari"
                 }
             ]
-        }
+        },
+        "specName": "calamari"
     },
     {
         "name": "QUARTZ",
@@ -2129,7 +2140,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-quartz"
                 }
             ]
-        }
+        },
+        "specName": "quartz"
     },
     {
         "name": "Bit.Country Pioneer",
@@ -2190,7 +2202,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-bit-country"
                 }
             ]
-        }
+        },
+        "specName": "pioneer-runtime"
     },
     {
         "name": "Acala",
@@ -2469,7 +2482,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-acala"
                 }
             ]
-        }
+        },
+        "specName": "acala"
     },
     {
         "name": "Astar",
@@ -2684,7 +2698,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-astar"
                 }
             ]
-        }
+        },
+        "specName": "astar"
     },
     {
         "name": "Parallel",
@@ -2938,7 +2953,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-parallel"
                 }
             ]
-        }
+        },
+        "specName": "parallel"
     },
     {
         "name": "CLV Parachain",
@@ -2985,7 +3001,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-clover"
                 }
             ]
-        }
+        },
+        "specName": "clover-mainnet"
     },
     {
         "name": "Polkadot Asset Hub",
@@ -3132,7 +3149,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-robonomics"
                 }
             ]
-        }
+        },
+        "specName": "robonomics"
     },
     {
         "name": "Encointer",
@@ -3401,7 +3419,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-kintsugi"
                 }
             ]
-        }
+        },
+        "specName": "kintsugi-parachain"
     },
     {
         "name": "Picasso",
@@ -3496,7 +3515,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-picasso"
                 }
             ]
-        }
+        },
+        "specName": "picasso"
     },
     {
         "name": "Zeitgeist",
@@ -3557,7 +3577,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-zeitgeist"
                 }
             ]
-        }
+        },
+        "specName": "zeitgeist"
     },
     {
         "name": "Litmus",
@@ -3608,7 +3629,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-litmus"
                 }
             ]
-        }
+        },
+        "specName": "litmus-parachain"
     },
     {
         "name": "Subsocial",
@@ -3653,7 +3675,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-subsocial"
                 }
             ]
-        }
+        },
+        "specName": "subsocial-parachain"
     },
     {
         "name": "Crust Shadow",
@@ -3704,7 +3727,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-shadow"
                 }
             ]
-        }
+        },
+        "specName": "crust-collator"
     },
     {
         "name": "Integritee Parachain",
@@ -3759,7 +3783,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-integritee"
                 }
             ]
-        }
+        },
+        "specName": "integritee-parachain"
     },
     {
         "name": "Centrifuge Parachain",
@@ -3814,7 +3839,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-centrifuge"
                 }
             ]
-        }
+        },
+        "specName": "centrifuge"
     },
     {
         "name": "HydraDX",
@@ -4104,7 +4130,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-hydra"
                 }
             ]
-        }
+        },
+        "specName": "hydradx"
     },
     {
         "name": "Interlay",
@@ -4355,7 +4382,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-interlay"
                 }
             ]
-        }
+        },
+        "specName": "interlay-parachain"
     },
     {
         "name": "Nodle Parachain",
@@ -4410,7 +4438,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-nodle"
                 }
             ]
-        }
+        },
+        "specName": "nodle-para"
     },
     {
         "name": "Phala",
@@ -4465,7 +4494,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-phala"
                 }
             ]
-        }
+        },
+        "specName": "phala"
     },
     {
         "name": "Turing",
@@ -4625,7 +4655,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-turing"
                 }
             ]
-        }
+        },
+        "specName": "turing"
     },
     {
         "name": "Aleph Zero",
@@ -4672,7 +4703,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-aleph-zero"
                 }
             ]
-        }
+        },
+        "specName": "aleph-node"
     },
     {
         "name": "Composable Finance",
@@ -4763,7 +4795,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-composable"
                 }
             ]
-        }
+        },
+        "specName": "composable"
     },
     {
         "name": "Polkadex",
@@ -4883,7 +4916,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-polkadex"
                 }
             ]
-        }
+        },
+        "specName": "node"
     },
     {
         "name": "OriginTrail Parachain",
@@ -4932,7 +4966,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-origin-trail"
                 }
             ]
-        }
+        },
+        "specName": "origintrail-parachain"
     },
     {
         "name": "Bifrost Polkadot",
@@ -5096,7 +5131,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-bifrost-polkadot"
                 }
             ]
-        }
+        },
+        "specName": "bifrost_polkadot"
     },
     {
         "name": "Litentry",
@@ -5141,7 +5177,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-litentry"
                 }
             ]
-        }
+        },
+        "specName": "litentry-parachain"
     },
     {
         "name": "UNIQUE",
@@ -5193,7 +5230,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-unique"
                 }
             ]
-        }
+        },
+        "specName": "unique"
     },
     {
         "name": "Mangata X",
@@ -5357,7 +5395,8 @@
                 "account": "https://polkaholic.io/account/{address}",
                 "extrinsic": "https://polkaholic.io/tx/{hash}"
             }
-        ]
+        ],
+        "specName": "mangata-parachain"
     },
     {
         "name": "Kabocha",
@@ -5397,7 +5436,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-kabocha"
                 }
             ]
-        }
+        },
+        "specName": "kabocha-parachain"
     },
     {
         "name": "Bajun",
@@ -5452,7 +5492,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-bajun"
                 }
             ]
-        }
+        },
+        "specName": "bajun"
     },
     {
         "name": "Imbue",
@@ -5492,7 +5533,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-imbue"
                 }
             ]
-        }
+        },
+        "specName": "imbue"
     },
     {
         "name": "Tinkernet",
@@ -5532,7 +5574,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-tinkernet"
                 }
             ]
-        }
+        },
+        "specName": "tinkernet_node"
     },
     {
         "name": "Amplitude",
@@ -5595,7 +5638,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-amplitude"
                 }
             ]
-        }
+        },
+        "specName": "amplitude"
     },
     {
         "name": "Ternoa",
@@ -5642,7 +5686,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-ternoa"
                 }
             ]
-        }
+        },
+        "specName": "mainnet"
     },
     {
         "name": "Kapex",
@@ -5682,7 +5727,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-kapex"
                 }
             ]
-        }
+        },
+        "specName": "totem-parachain"
     },
     {
         "name": "Polymesh",
@@ -5712,7 +5758,8 @@
                 "account": "https://polymesh.subscan.io/account/{address}",
                 "multisig": "https://polymesh.subscan.io/multisig_extrinsic/{index}?call_hash={callHash}"
             }
-        ]
+        ],
+        "specName": "polymesh_mainnet"
     },
     {
         "name": "DAO IPCI",
@@ -5752,7 +5799,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-dao-ipci"
                 }
             ]
-        }
+        },
+        "specName": "ipci"
     },
     {
         "name": "Myriad",
@@ -5788,7 +5836,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-myriad"
                 }
             ]
-        }
+        },
+        "specName": "appchain"
     },
     {
         "name": "XX network",
@@ -5845,7 +5894,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-xx-network"
                 }
             ]
-        }
+        },
+        "specName": "xxnetwork"
     },
     {
         "name": "Pendulum",
@@ -5909,7 +5959,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-pendulum"
                 }
             ]
-        }
+        },
+        "specName": "pendulum"
     },
     {
         "name": "Crust",
@@ -5951,7 +6002,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-crust"
                 }
             ]
-        }
+        },
+        "specName": "polkadot-crust-parachain"
     },
     {
         "name": "Aventus",
@@ -5989,7 +6041,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-aventus"
                 }
             ]
-        }
+        },
+        "specName": "avn-parachain"
     },
     {
         "name": "Hashed Network",
@@ -6022,7 +6075,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-hashed-network"
                 }
             ]
-        }
+        },
+        "specName": "luhn"
     },
     {
         "name": "Bittensor",
@@ -6055,7 +6109,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-bittensor"
                 }
             ]
-        }
+        },
+        "specName": "node-subtensor"
     },
     {
         "name": "Ajuna",
@@ -6084,7 +6139,8 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Ajuna_(AJUN).svg",
                 "name": "Ajuna"
             }
-        ]
+        ],
+        "specName": "ajuna"
     },
     {
         "name": "3DPass",
@@ -6132,7 +6188,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-3dpass"
                 }
             ]
-        }
+        },
+        "specName": "poscan-runtime"
     },
     {
         "name": "Frequency",
@@ -6176,7 +6233,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/frequency"
                 }
             ]
-        }
+        },
+        "specName": "frequency"
     },
     {
         "name": "Vara",
@@ -6216,7 +6274,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet---vara"
                 }
             ]
-        }
+        },
+        "specName": "vara"
     },
     {
         "name": "GIANT",
@@ -6245,7 +6304,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet---giant"
                 }
             ]
-        }
+        },
+        "specName": "giant-runtime"
     },
     {
         "name": "Polkadot Bridge Hub",
@@ -6409,7 +6469,8 @@
                 "account": "https://krest.subscan.io/account/{address}",
                 "multisig": "https://krest.subscan.io/multisig_extrinsic/{index}?call_hash={callHash}"
             }
-        ]
+        ],
+        "specName": "peaq-node-krest"
     },
     {
         "name": "Jur",
@@ -6445,7 +6506,8 @@
                 "account": "https://jur.io/explorer/jur/account/{address}",
                 "event": "https://jur.io/explorer/jur/event/{event}"
             }
-        ]
+        ],
+        "specName": "jur-node"
     },
     {
         "name": "Enjin",
@@ -6490,7 +6552,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/enjin-matrixchain"
                 }
             ]
-        }
+        },
+        "specName": "matrix-enjin"
     },
     {
         "name": "Watr",
@@ -6512,6 +6575,7 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Watr.svg",
                 "name": "WATR token"
             }
-        ]
+        ],
+        "specName": "watr-mainnet"
     }
 ]

--- a/chains/v1/chains.json
+++ b/chains/v1/chains.json
@@ -239,7 +239,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-westend"
                 }
             ]
-        }
+        },
+        "specName": "westend"
     },
     {
         "name": "Kusama Asset Hub",
@@ -375,7 +376,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-statemine"
                 }
             ]
-        }
+        },
+        "specName": "statemine"
     },
     {
         "name": "Karura",
@@ -1653,7 +1655,8 @@
                 "name": "Sub.ID",
                 "account": "https://sub.id/{address}"
             }
-        ]
+        ],
+        "specName": "edgeware"
     },
     {
         "name": "Khala",
@@ -3094,7 +3097,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-statemint"
                 }
             ]
-        }
+        },
+        "specName": "statemint"
     },
     {
         "name": "Robonomics",
@@ -3202,7 +3206,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-encointer"
                 }
             ]
-        }
+        },
+        "specName": "encointer-parachain"
     },
     {
         "name": "Kintsugi",
@@ -6351,7 +6356,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/polkadot-bridgehub"
                 }
             ]
-        }
+        },
+        "specName": "bridge-hub-polkadot"
     },
     {
         "name": "Kusama Bridge Hub",
@@ -6389,7 +6395,8 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Kusama_(KSM).svg",
                 "name": "Kusama"
             }
-        ]
+        ],
+        "specName": "bridge-hub-kusama"
     },
     {
         "name": "Polkadot Collectives",
@@ -6435,7 +6442,8 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Polkadot_(DOT).svg",
                 "name": "Polkadot"
             }
-        ]
+        ],
+        "specName": "collectives"
     },
     {
         "name": "krest",

--- a/chains/v1/chains_dev.json
+++ b/chains/v1/chains_dev.json
@@ -239,7 +239,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-westend"
                 }
             ]
-        }
+        },
+        "specName": "westend"
     },
     {
         "name": "Westmint",
@@ -455,7 +456,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-statemine"
                 }
             ]
-        }
+        },
+        "specName": "statemine"
     },
     {
         "name": "Karura",
@@ -1627,7 +1629,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-edgeware"
                 }
             ]
-        }
+        },
+        "specName": "edgeware"
     },
     {
         "name": "Parallel Heiko",
@@ -2853,52 +2856,6 @@
         "specName": "acala"
     },
     {
-        "name": "Acala Mandala",
-        "addressPrefix": 42,
-        "chainId": "0x23fc729c2cdb7bd6770a4e8c58748387cc715fcf338f1f74a16833d90383f4b0",
-        "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/chains/Acala_Mandala_Testnet.svg",
-        "options": [
-            "testnet"
-        ],
-        "nodes": [
-            {
-                "url": "wss://mandala-rpc.aca-staging.network/ws",
-                "name": "Acala node"
-            }
-        ],
-        "assets": [
-            {
-                "assetId": 0,
-                "symbol": "ACA",
-                "precision": 12,
-                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Acala_(ACA).svg",
-                "name": "Acala"
-            },
-            {
-                "assetId": 1,
-                "symbol": "DOT",
-                "precision": 10,
-                "type": "orml",
-                "priceId": "polkadot",
-                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Polkadot_(DOT).svg",
-                "typeExtras": {
-                    "currencyIdScale": "0x0002",
-                    "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
-                    "existentialDeposit": "1000000"
-                },
-                "name": "Polkadot"
-            }
-        ],
-        "explorers": [
-            {
-                "name": "Subscan",
-                "extrinsic": "https://acala-testnet.subscan.io/extrinsic/{hash}",
-                "account": "https://acala-testnet.subscan.io/account/{address}",
-                "multisig": "https://acala-testnet.subscan.io/multisig_extrinsic/{index}?call_hash={callHash}"
-            }
-        ]
-    },
-    {
         "name": "Astar",
         "addressPrefix": 5,
         "chainId": "0x9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
@@ -3503,7 +3460,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-statemint"
                 }
             ]
-        }
+        },
+        "specName": "statemint"
     },
     {
         "name": "Robonomics",
@@ -3570,7 +3528,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-robonomics"
                 }
             ]
-        }
+        },
+        "specName": "robonomics"
     },
     {
         "name": "Encointer",
@@ -3622,7 +3581,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-encointer"
                 }
             ]
-        }
+        },
+        "specName": "encointer-parachain"
     },
     {
         "name": "Picasso",
@@ -4657,30 +4617,6 @@
             ]
         },
         "specName": "nodle-para"
-    },
-    {
-        "name": "Singular testnet",
-        "addressPrefix": 0,
-        "chainId": "0x55b88a59dded27563391d619d805572dd6b6b89d302b0dd792d01b3c41cfe5b1",
-        "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/chains/Singular_Testnet.svg",
-        "options": [
-            "testnet"
-        ],
-        "nodes": [
-            {
-                "url": "wss://staging.node.rmrk.app",
-                "name": "Singular DEV node"
-            }
-        ],
-        "assets": [
-            {
-                "assetId": 0,
-                "symbol": "KSM",
-                "precision": 12,
-                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Kusama_(KSM).svg",
-                "name": "Kusama"
-            }
-        ]
     },
     {
         "name": "Phala",
@@ -6244,7 +6180,7 @@
         ],
         "nodes": [
             {
-                "url": "wss://novasama.uz",
+                "url": "wss://novasama.co",
                 "name": "Development node"
             }
         ],
@@ -6271,7 +6207,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/novasama-test-kusama"
                 }
             ]
-        }
+        },
+        "specName": "kusama"
     },
     {
         "name": "DAO IPCI",
@@ -7082,31 +7019,6 @@
         "specName": "giant-runtime"
     },
     {
-        "name": "GIANT Testnet",
-        "addressPrefix": 42,
-        "chainId": "0xc9824829d23066e7dd92b80cfef52559c7692866fcfc3530e737e3fe01410eef",
-        "parentId": "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
-        "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/chains/Giant_Testnet.svg",
-        "options": [
-            "testnet"
-        ],
-        "nodes": [
-            {
-                "url": "wss://rpc-4-us-east-1-dev.giantprotocol.org:443",
-                "name": "Giant testnet node"
-            }
-        ],
-        "assets": [
-            {
-                "assetId": 0,
-                "symbol": "GIANT",
-                "precision": 12,
-                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/GIANT.svg",
-                "name": "Giant"
-            }
-        ]
-    },
-    {
         "name": "Polkadot Bridge Hub",
         "addressPrefix": 0,
         "chainId": "0xdcf691b5a3fbe24adc99ddc959c0561b973e329b1aef4c4b22e7bb2ddecb4464",
@@ -7150,7 +7062,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/polkadot-bridgehub"
                 }
             ]
-        }
+        },
+        "specName": "bridge-hub-polkadot"
     },
     {
         "name": "Kusama Bridge Hub",
@@ -7196,7 +7109,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet---kusama-bridgehub"
                 }
             ]
-        }
+        },
+        "specName": "bridge-hub-kusama"
     },
     {
         "name": "Polkadot Collectives",
@@ -7250,7 +7164,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/polkadot-collectives"
                 }
             ]
-        }
+        },
+        "specName": "collectives"
     },
     {
         "name": "Amplitude Foucoco",

--- a/chains/v1/chains_dev.json
+++ b/chains/v1/chains_dev.json
@@ -83,7 +83,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-polkadot"
                 }
             ]
-        }
+        },
+        "specName": "polkadot"
     },
     {
         "name": "Kusama",
@@ -173,7 +174,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-kusama"
                 }
             ]
-        }
+        },
+        "specName": "kusama"
     },
     {
         "name": "Westend",
@@ -316,7 +318,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet---westmint-test"
                 }
             ]
-        }
+        },
+        "specName": "westmint"
     },
     {
         "name": "Kusama Asset Hub",
@@ -889,7 +892,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-karura"
                 }
             ]
-        }
+        },
+        "specName": "karura"
     },
     {
         "name": "Shiden",
@@ -1091,7 +1095,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-shiden"
                 }
             ]
-        }
+        },
+        "specName": "shiden"
     },
     {
         "name": "Bifrost Kusama",
@@ -1347,7 +1352,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-bifrost"
                 }
             ]
-        }
+        },
+        "specName": "bifrost"
     },
     {
         "name": "Kintsugi",
@@ -1564,7 +1570,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-kintsugi"
                 }
             ]
-        }
+        },
+        "specName": "kintsugi-parachain"
     },
     {
         "name": "Edgeware",
@@ -1797,7 +1804,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-parallel-heiko"
                 }
             ]
-        }
+        },
+        "specName": "heiko"
     },
     {
         "name": "Basilisk",
@@ -1926,7 +1934,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-basilisk"
                 }
             ]
-        }
+        },
+        "specName": "basilisk"
     },
     {
         "name": "Altair",
@@ -1977,7 +1986,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-altair"
                 }
             ]
-        }
+        },
+        "specName": "altair"
     },
     {
         "name": "Khala",
@@ -2213,7 +2223,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-khala"
                 }
             ]
-        }
+        },
+        "specName": "khala"
     },
     {
         "name": "KILT",
@@ -2272,7 +2283,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-kilt"
                 }
             ]
-        }
+        },
+        "specName": "kilt-spiritnet"
     },
     {
         "name": "KILT Peregrine",
@@ -2304,7 +2316,8 @@
                 "account": "https://kilt-testnet.subscan.io/account/{address}",
                 "multisig": "https://kilt-testnet.subscan.io/multisig_extrinsic/{index}?call_hash={callHash}"
             }
-        ]
+        ],
+        "specName": "mashnet-node"
     },
     {
         "name": "Calamari",
@@ -2433,7 +2446,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-calamari"
                 }
             ]
-        }
+        },
+        "specName": "calamari"
     },
     {
         "name": "QUARTZ",
@@ -2493,7 +2507,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-quartz"
                 }
             ]
-        }
+        },
+        "specName": "quartz"
     },
     {
         "name": "Bit.Country Pioneer",
@@ -2554,7 +2569,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-bit-country"
                 }
             ]
-        }
+        },
+        "specName": "pioneer-runtime"
     },
     {
         "name": "Acala",
@@ -2833,7 +2849,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-acala"
                 }
             ]
-        }
+        },
+        "specName": "acala"
     },
     {
         "name": "Acala Mandala",
@@ -3090,7 +3107,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-astar"
                 }
             ]
-        }
+        },
+        "specName": "astar"
     },
     {
         "name": "Parallel",
@@ -3344,7 +3362,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-parallel"
                 }
             ]
-        }
+        },
+        "specName": "parallel"
     },
     {
         "name": "CLV Parachain",
@@ -3391,7 +3410,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-clover"
                 }
             ]
-        }
+        },
+        "specName": "clover-mainnet"
     },
     {
         "name": "Polkadot Asset Hub",
@@ -3697,7 +3717,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-picasso"
                 }
             ]
-        }
+        },
+        "specName": "picasso"
     },
     {
         "name": "Zeitgeist",
@@ -3758,7 +3779,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-zeitgeist"
                 }
             ]
-        }
+        },
+        "specName": "zeitgeist"
     },
     {
         "name": "Litmus",
@@ -3809,7 +3831,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-litmus"
                 }
             ]
-        }
+        },
+        "specName": "litmus-parachain"
     },
     {
         "name": "Subsocial",
@@ -3854,7 +3877,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-subsocial"
                 }
             ]
-        }
+        },
+        "specName": "subsocial-parachain"
     },
     {
         "name": "Crust Shadow",
@@ -3905,7 +3929,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-shadow"
                 }
             ]
-        }
+        },
+        "specName": "crust-collator"
     },
     {
         "name": "Integritee Parachain",
@@ -3960,7 +3985,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-integritee"
                 }
             ]
-        }
+        },
+        "specName": "integritee-parachain"
     },
     {
         "name": "Centrifuge Parachain",
@@ -4015,7 +4041,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-centrifuge"
                 }
             ]
-        }
+        },
+        "specName": "centrifuge"
     },
     {
         "name": "HydraDX",
@@ -4320,7 +4347,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-hydra"
                 }
             ]
-        }
+        },
+        "specName": "hydradx"
     },
     {
         "name": "Interlay",
@@ -4571,7 +4599,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-interlay"
                 }
             ]
-        }
+        },
+        "specName": "interlay-parachain"
     },
     {
         "name": "Nodle Parachain",
@@ -4626,7 +4655,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-nodle"
                 }
             ]
-        }
+        },
+        "specName": "nodle-para"
     },
     {
         "name": "Singular testnet",
@@ -4705,7 +4735,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-phala"
                 }
             ]
-        }
+        },
+        "specName": "phala"
     },
     {
         "name": "Turing",
@@ -4865,7 +4896,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-turing"
                 }
             ]
-        }
+        },
+        "specName": "turing"
     },
     {
         "name": "Aleph Zero",
@@ -4912,7 +4944,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-aleph-zero"
                 }
             ]
-        }
+        },
+        "specName": "aleph-node"
     },
     {
         "name": "Composable Finance",
@@ -5003,7 +5036,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-composable"
                 }
             ]
-        }
+        },
+        "specName": "composable"
     },
     {
         "name": "Polkadex",
@@ -5123,7 +5157,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-polkadex"
                 }
             ]
-        }
+        },
+        "specName": "node"
     },
     {
         "name": "OriginTrail Parachain",
@@ -5172,7 +5207,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-origin-trail"
                 }
             ]
-        }
+        },
+        "specName": "origintrail-parachain"
     },
     {
         "name": "Bifrost Polkadot",
@@ -5336,7 +5372,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-bifrost-polkadot"
                 }
             ]
-        }
+        },
+        "specName": "bifrost_polkadot"
     },
     {
         "name": "Litentry",
@@ -5381,7 +5418,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-litentry"
                 }
             ]
-        }
+        },
+        "specName": "litentry-parachain"
     },
     {
         "name": "UNIQUE",
@@ -5433,7 +5471,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-unique"
                 }
             ]
-        }
+        },
+        "specName": "unique"
     },
     {
         "name": "Mangata X",
@@ -5597,7 +5636,8 @@
                 "account": "https://polkaholic.io/account/{address}",
                 "extrinsic": "https://polkaholic.io/tx/{hash}"
             }
-        ]
+        ],
+        "specName": "mangata-parachain"
     },
     {
         "name": "Aleph Zero Testnet",
@@ -5622,7 +5662,8 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Default.svg",
                 "name": "Aleph Zero Testnet"
             }
-        ]
+        ],
+        "specName": "aleph-node"
     },
     {
         "name": "Moonbase Relay Testnet",
@@ -5646,7 +5687,8 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Default.svg",
                 "name": "Test token"
             }
-        ]
+        ],
+        "specName": "westend"
     },
     {
         "name": "Polymesh Testnet",
@@ -5679,7 +5721,8 @@
                 "account": "https://polymesh.subscan.io/account/{address}",
                 "multisig": "https://polymesh.subscan.io/multisig_extrinsic/{index}?call_hash={callHash}"
             }
-        ]
+        ],
+        "specName": "polymesh_testnet"
     },
     {
         "name": "Kabocha",
@@ -5719,7 +5762,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-kabocha"
                 }
             ]
-        }
+        },
+        "specName": "kabocha-parachain"
     },
     {
         "name": "Bajun",
@@ -5774,7 +5818,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-bajun"
                 }
             ]
-        }
+        },
+        "specName": "bajun"
     },
     {
         "name": "Imbue",
@@ -5814,7 +5859,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-imbue"
                 }
             ]
-        }
+        },
+        "specName": "imbue"
     },
     {
         "name": "Rococo Testnet",
@@ -5838,7 +5884,8 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Rococo_(ROC).svg",
                 "name": "Rococo Testnet"
             }
-        ]
+        ],
+        "specName": "rococo"
     },
     {
         "name": "Tinkernet",
@@ -5878,7 +5925,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-tinkernet"
                 }
             ]
-        }
+        },
+        "specName": "tinkernet_node"
     },
     {
         "name": "Amplitude",
@@ -5941,7 +5989,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-amplitude"
                 }
             ]
-        }
+        },
+        "specName": "amplitude"
     },
     {
         "name": "Ternoa",
@@ -5988,7 +6037,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-ternoa"
                 }
             ]
-        }
+        },
+        "specName": "mainnet"
     },
     {
         "name": "Ternoa Alphanet",
@@ -6020,7 +6070,8 @@
                 "extrinsic": "https://explorer-alphanet.ternoa.dev/extrinsic/{hash}",
                 "account": "https://explorer-alphanet.ternoa.dev/{address}"
             }
-        ]
+        ],
+        "specName": "alphanet"
     },
     {
         "name": "Turing Staging",
@@ -6044,7 +6095,8 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Turing_(TUR).svg",
                 "name": "Turing"
             }
-        ]
+        ],
+        "specName": "turing"
     },
     {
         "name": "Governance2 Testnet",
@@ -6074,7 +6126,8 @@
                 "name": "Governance2 Testnet explorer",
                 "account": "https://gov2.statescan.io/#/accounts/{address}"
             }
-        ]
+        ],
+        "specName": "governance2"
     },
     {
         "name": "Kapex",
@@ -6114,7 +6167,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-kapex"
                 }
             ]
-        }
+        },
+        "specName": "totem-parachain"
     },
     {
         "name": "Polymesh",
@@ -6152,7 +6206,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-polymesh"
                 }
             ]
-        }
+        },
+        "specName": "polymesh_mainnet"
     },
     {
         "name": "Beresheet",
@@ -6176,7 +6231,8 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Default.svg",
                 "name": "Beresheet"
             }
-        ]
+        ],
+        "specName": "beresheet"
     },
     {
         "name": "Novasama Testnet - Kusama",
@@ -6255,7 +6311,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-dao-ipci"
                 }
             ]
-        }
+        },
+        "specName": "ipci"
     },
     {
         "name": "Myriad",
@@ -6291,7 +6348,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-myriad"
                 }
             ]
-        }
+        },
+        "specName": "appchain"
     },
     {
         "name": "Fusotao",
@@ -6319,7 +6377,8 @@
                 "name": "Explorer",
                 "account": "https://explorer.mainnet.oct.network/fusotao/accounts/{address}"
             }
-        ]
+        ],
+        "specName": "fusotao"
     },
     {
         "name": "XX network",
@@ -6376,7 +6435,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-xx-network"
                 }
             ]
-        }
+        },
+        "specName": "xxnetwork"
     },
     {
         "name": "Pendulum",
@@ -6440,7 +6500,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-pendulum"
                 }
             ]
-        }
+        },
+        "specName": "pendulum"
     },
     {
         "name": "Aventus Testnet",
@@ -6471,7 +6532,8 @@
                 "extrinsic": "https://explorer.testnet.aventus.io/transaction/{hash}",
                 "account": "https://explorer.testnet.aventus.io/address/{address}"
             }
-        ]
+        ],
+        "specName": "avn-parachain"
     },
     {
         "name": "Aventus",
@@ -6509,7 +6571,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-aventus"
                 }
             ]
-        }
+        },
+        "specName": "avn-parachain"
     },
     {
         "name": "Crust",
@@ -6551,7 +6614,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-crust"
                 }
             ]
-        }
+        },
+        "specName": "polkadot-crust-parachain"
     },
     {
         "name": "Kintsugi Testnet",
@@ -6737,7 +6801,8 @@
                 },
                 "name": "USD Tether"
             }
-        ]
+        ],
+        "specName": "kintsugi-parachain"
     },
     {
         "name": "Hashed Network",
@@ -6770,7 +6835,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-hashed-network"
                 }
             ]
-        }
+        },
+        "specName": "luhn"
     },
     {
         "name": "Bittensor",
@@ -6809,7 +6875,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-bittensor"
                 }
             ]
-        }
+        },
+        "specName": "node-subtensor"
     },
     {
         "name": "3DPass",
@@ -6857,7 +6924,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-3dpass"
                 }
             ]
-        }
+        },
+        "specName": "poscan-runtime"
     },
     {
         "name": "Ajuna",
@@ -6894,7 +6962,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-ajuna"
                 }
             ]
-        }
+        },
+        "specName": "ajuna"
     },
     {
         "name": "Frequency",
@@ -6938,7 +7007,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/frequency"
                 }
             ]
-        }
+        },
+        "specName": "frequency"
     },
     {
         "name": "Vara",
@@ -6978,7 +7048,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet---vara"
                 }
             ]
-        }
+        },
+        "specName": "vara"
     },
     {
         "name": "GIANT",
@@ -7007,7 +7078,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet---giant"
                 }
             ]
-        }
+        },
+        "specName": "giant-runtime"
     },
     {
         "name": "GIANT Testnet",
@@ -7203,7 +7275,8 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Amplitude_(AMPE).svg",
                 "name": "Amplitude"
             }
-        ]
+        ],
+        "specName": "foucoco"
     },
     {
         "name": "Interlay Testnet",
@@ -7425,7 +7498,8 @@
                 },
                 "name": "Interlay DOT"
             }
-        ]
+        ],
+        "specName": "interlay-parachain"
     },
     {
         "name": "krest",
@@ -7467,7 +7541,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet---krest"
                 }
             ]
-        }
+        },
+        "specName": "peaq-node-krest"
     },
     {
         "name": "Jur",
@@ -7503,7 +7578,8 @@
                 "account": "https://jur.io/explorer/jur/account/{address}",
                 "event": "https://jur.io/explorer/jur/event/{event}"
             }
-        ]
+        ],
+        "specName": "jur-node"
     },
     {
         "name": "Manta",
@@ -7533,7 +7609,8 @@
                 "account": "https://manta.subscan.io/account/{address}",
                 "multisig": "https://manta.subscan.io/multisig_extrinsic/{index}?call_hash={callHash}"
             }
-        ]
+        ],
+        "specName": "manta"
     },
     {
         "name": "Vara Testnet",
@@ -7557,7 +7634,8 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/tVARA.svg",
                 "name": "Vara testnet"
             }
-        ]
+        ],
+        "specName": "vara"
     },
     {
         "name": "Enjin",
@@ -7602,7 +7680,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/enjin-matrixchain"
                 }
             ]
-        }
+        },
+        "specName": "matrix-enjin"
     },
     {
         "name": "Rococo Asset Hub",
@@ -7655,7 +7734,8 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet---westmint"
                 }
             ]
-        }
+        },
+        "specName": "statemine"
     },
     {
         "name": "EWX Staging Parachain Argon",
@@ -7680,7 +7760,8 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Default_(VT).svg",
                 "name": "VT token"
             }
-        ]
+        ],
+        "specName": "ewx-parachain"
     },
     {
         "name": "Watr",
@@ -7702,7 +7783,8 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Watr.svg",
                 "name": "WATR token"
             }
-        ]
+        ],
+        "specName": "watr-mainnet"
     },
     {
         "name": "Joystream",
@@ -7746,6 +7828,7 @@
                     "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet---joystream"
                 }
             ]
-        }
+        },
+        "specName": "joystream-node"
     }
 ]

--- a/chains/v1/chains_dev.json
+++ b/chains/v1/chains_dev.json
@@ -276,6 +276,30 @@
                     "assetId": "81"
                 },
                 "name": "Siri"
+            },
+            {
+                "assetId": 2,
+                "symbol": "DOT",
+                "precision": 10,
+                "type": "statemine",
+                "priceId": "polkadot",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Polkadot_(DOT).svg",
+                "typeExtras": {
+                    "assetId": "0x02010902",
+                    "palletName": "ForeignAssets"
+                },
+                "name": "Polkadot"
+            },
+            {
+                "assetId": 3,
+                "symbol": "JOE",
+                "precision": 3,
+                "type": "statemine",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Default.svg",
+                "typeExtras": {
+                    "assetId": "8"
+                },
+                "name": "JOE token"
             }
         ],
         "explorers": [
@@ -284,7 +308,15 @@
                 "account": "https://westmint.statescan.io/#/accounts/{address}",
                 "event": "https://westmint.statescan.io/#/events/{event}"
             }
-        ]
+        ],
+        "externalApi": {
+            "history": [
+                {
+                    "type": "subquery",
+                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet---westmint-test"
+                }
+            ]
+        }
     },
     {
         "name": "Kusama Asset Hub",
@@ -428,6 +460,9 @@
         "chainId": "0xbaf5aabe40646d11f0ee8abbdc64f4a4b7674925cba08e4a05ff9ebed6e2126b",
         "parentId": "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/chains/Karura.svg",
+        "options": [
+            "multisig"
+        ],
         "nodes": [
             {
                 "url": "wss://karura-rpc-0.aca-api.network",
@@ -444,6 +479,10 @@
             {
                 "url": "wss://karura-rpc-3.aca-api.network/ws",
                 "name": "Acala Foundation 3 node"
+            },
+            {
+                "url": "wss://karura.api.onfinality.io/public-ws",
+                "name": "Onfinality node"
             }
         ],
         "assets": [
@@ -1900,10 +1939,6 @@
         ],
         "nodes": [
             {
-                "url": "wss://fullnode.altair.centrifuge.io",
-                "name": "Centrifuge"
-            },
-            {
                 "url": "wss://altair.api.onfinality.io/public-ws",
                 "name": "OnFinality node"
             }
@@ -2191,6 +2226,10 @@
         ],
         "nodes": [
             {
+                "url": "wss://kilt-rpc.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
                 "url": "wss://spiritnet.kilt.io/",
                 "name": "KILT Protocol node"
             },
@@ -2349,7 +2388,7 @@
                 "typeExtras": {
                     "assetId": "15"
                 },
-                "name": "Should be included in scripts/data/assetsNameMap"
+                "name": "DAI-Karura"
             },
             {
                 "assetId": 6,
@@ -2361,7 +2400,7 @@
                 "typeExtras": {
                     "assetId": "16"
                 },
-                "name": "Should be included in scripts/data/assetsNameMap"
+                "name": "USDC-Karura"
             }
         ],
         "explorers": [
@@ -3874,6 +3913,9 @@
         "chainId": "0xcdedc8eadbfa209d3f207bba541e57c3c58a667b05a2e1d1e86353c9000758da",
         "parentId": "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/chains/Integritee.svg",
+        "options": [
+            "multisig"
+        ],
         "nodes": [
             {
                 "url": "wss://kusama.api.integritee.network",
@@ -4241,6 +4283,21 @@
                     "transfersEnabled": true
                 },
                 "name": "Moonbeam"
+            },
+            {
+                "assetId": 17,
+                "symbol": "INTR",
+                "precision": 10,
+                "type": "orml",
+                "priceId": "interlay",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Interlay_(INTR).svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x11000000",
+                    "currencyIdType": "u32",
+                    "existentialDeposit": "6164274209",
+                    "transfersEnabled": true
+                },
+                "name": "Interlay"
             }
         ],
         "explorers": [
@@ -4492,21 +4549,6 @@
                     "transfersEnabled": false
                 },
                 "name": "Interlay DOT"
-            },
-            {
-                "assetId": 17,
-                "symbol": "INTR",
-                "precision": 10,
-                "type": "orml",
-                "priceId": "interlay",
-                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Interlay_(INTR).svg",
-                "typeExtras": {
-                    "currencyIdScale": "0x11000000",
-                    "currencyIdType": "u32",
-                    "existentialDeposit": "6164274209",
-                    "transfersEnabled": true
-                },
-                "name": "Interlay"
             }
         ],
         "explorers": [
@@ -5459,6 +5501,7 @@
                 "symbol": "TUR",
                 "precision": 10,
                 "type": "orml",
+                "priceId": "turing-network",
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Turing_(TUR).svg",
                 "typeExtras": {
                     "currencyIdScale": "0x07000000",
@@ -6034,49 +6077,14 @@
         ]
     },
     {
-        "name": "Kylin",
-        "addressPrefix": 42,
-        "chainId": "0xf2584690455deda322214e97edfffaf4c1233b6e4625e39478496b3e2f5a44c5",
-        "parentId": "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
-        "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/chains/Kylin.svg",
-        "nodes": [
-            {
-                "url": "wss://polkadot.kylin-node.co.uk",
-                "name": "Kylin node"
-            }
-        ],
-        "assets": [
-            {
-                "assetId": 0,
-                "symbol": "KYL",
-                "precision": 18,
-                "priceId": "kylin-network",
-                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Kylin_(KYL).svg",
-                "name": "Kylin"
-            }
-        ],
-        "explorers": [
-            {
-                "name": "Polkaholic",
-                "account": "https://polkaholic.io/account/{address}",
-                "extrinsic": "https://polkaholic.io/tx/{hash}"
-            }
-        ],
-        "externalApi": {
-            "history": [
-                {
-                    "type": "subquery",
-                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-kylin"
-                }
-            ]
-        }
-    },
-    {
         "name": "Kapex",
         "addressPrefix": 2007,
         "chainId": "0x7838c3c774e887c0a53bcba9e64f702361a1a852d5550b86b58cd73827fa1e1e",
         "parentId": "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/chains/Totem.svg",
+        "options": [
+            "multisig"
+        ],
         "nodes": [
             {
                 "url": "wss://kapex-rpc.dwellir.com",
@@ -6322,6 +6330,14 @@
             "multisig"
         ],
         "nodes": [
+            {
+                "url": "wss://xxnetwork-rpc.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc.xx.network",
+                "name": "xx Foundation node"
+            },
             {
                 "url": "wss://rpc-hetzner.xx.network",
                 "name": "xx Foundation node"
@@ -6780,6 +6796,12 @@
                 "name": "Fusotao token"
             }
         ],
+        "explorers": [
+            {
+                "name": "SCAN",
+                "account": "https://bittensor.com/scan/address/{address}"
+            }
+        ],
         "externalApi": {
             "history": [
                 {
@@ -6798,6 +6820,14 @@
             "multisig"
         ],
         "nodes": [
+            {
+                "url": "wss://rpc.3dpscan.io",
+                "name": "3DPass node"
+            },
+            {
+                "url": "wss://rpc.3dpass.org",
+                "name": "3DPass node"
+            },
             {
                 "url": "wss://rpc2.3dpass.org",
                 "name": "3DPass node"
@@ -7575,6 +7605,59 @@
         }
     },
     {
+        "name": "Rococo Asset Hub",
+        "addressPrefix": 42,
+        "chainId": "0x7c34d42fc815d392057c78b49f2755c753440ccd38bcb0405b3bcfb601d08734",
+        "parentId": "0x6408de7737c59c238890533af25896a2c20608d8b380bb01029acb392781063e",
+        "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/chains/Polkadot_Asset_Hub.svg",
+        "options": [
+            "testnet"
+        ],
+        "nodes": [
+            {
+                "url": "wss://rococo-asset-hub-rpc.polkadot.io",
+                "name": "Parity node"
+            }
+        ],
+        "assets": [
+            {
+                "assetId": 0,
+                "symbol": "ROC",
+                "precision": 12,
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Rococo_(ROC).svg",
+                "name": "Rococo Testnet"
+            },
+            {
+                "assetId": 1,
+                "symbol": "HOP",
+                "precision": 12,
+                "type": "statemine",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Default.svg",
+                "typeExtras": {
+                    "assetId": "0x010100b11c",
+                    "palletName": "ForeignAssets"
+                },
+                "name": "HOP token"
+            }
+        ],
+        "explorers": [
+            {
+                "name": "Subscan",
+                "extrinsic": "https://assethub-rococo.subscan.io/extrinsic/{hash}",
+                "account": "https://assethub-rococo.subscan.io/account/{address}",
+                "multisig": "https://assethub-rococo.subscan.io/multisig_extrinsic/{index}?call_hash={callHash}"
+            }
+        ],
+        "externalApi": {
+            "history": [
+                {
+                    "type": "subquery",
+                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet---westmint"
+                }
+            ]
+        }
+    },
+    {
         "name": "EWX Staging Parachain Argon",
         "addressPrefix": 42,
         "chainId": "0x6ab1bd8aed6d5fdcaf347826bfcd0172681181edf8356b90cb3cf47076698ae2",
@@ -7595,7 +7678,7 @@
                 "symbol": "VT",
                 "precision": 18,
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Default_(VT).svg",
-                "name": "Should be included in scripts/data/assetsNameMap"
+                "name": "VT token"
             }
         ]
     },
@@ -7617,7 +7700,7 @@
                 "symbol": "WATR",
                 "precision": 18,
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/Watr.svg",
-                "name": "Should be included in scripts/data/assetsNameMap"
+                "name": "WATR token"
             }
         ]
     },
@@ -7637,8 +7720,9 @@
                 "assetId": 0,
                 "symbol": "JOY",
                 "precision": 10,
+                "priceId": "joystream",
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/assets/white/JOY.svg",
-                "name": "Should be included in scripts/data/assetsNameMap"
+                "name": "Joystream"
             }
         ],
         "explorers": [
@@ -7648,6 +7732,20 @@
                 "account": "https://joystream.subscan.io/account/{address}",
                 "multisig": "https://joystream.subscan.io/multisig_extrinsic/{index}?call_hash={callHash}"
             }
-        ]
+        ],
+        "externalApi": {
+            "staking": [
+                {
+                    "type": "subquery",
+                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet---joystream"
+                }
+            ],
+            "history": [
+                {
+                    "type": "subquery",
+                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet---joystream"
+                }
+            ]
+        }
     }
 ]

--- a/metadataCreator/src/models/Chain.ts
+++ b/metadataCreator/src/models/Chain.ts
@@ -173,7 +173,7 @@ export class Chain {
         for (const node of this.nodes) {
             try {
                 const api = await this.wrapApiWithTimer(node);
-    
+
                 if (api?.isConnected) {
                     this.api = api;
                     break;
@@ -187,7 +187,7 @@ export class Chain {
 
     private async wrapApiWithTimer(node: NodeElement): Promise<ApiPromise | void> {
         const wsProvider = new WsProvider(node.url);
-    
+
         let timeoutId: NodeJS.Timeout | undefined;
         const timeoutPromise = new Promise<void>((_, reject) => {
             timeoutId = setTimeout(() => {
@@ -195,9 +195,9 @@ export class Chain {
                 reject(new Error(`Connection timeout for ${node.url}`));
             }, 20_000);
         });
-    
+
         const apiPromise = ApiPromise.create({ provider: wsProvider });
-    
+
         try {
             const api = await Promise.race([apiPromise, timeoutPromise]);
             if (api?.isConnected) {

--- a/metadataCreator/src/models/MultisigVersionStorage.ts
+++ b/metadataCreator/src/models/MultisigVersionStorage.ts
@@ -36,7 +36,7 @@ export class MultisigVersionStorage {
         return networkList
     }
 
-        addNetwork(network: MultisigNetwork): void {
-            this.networks.push(network);
-        }
+    addNetwork(network: MultisigNetwork): void {
+        this.networks.push(network);
     }
+}

--- a/metadataCreator/src/updateSpecName.ts
+++ b/metadataCreator/src/updateSpecName.ts
@@ -26,11 +26,11 @@ async function updateSpecName(url: string) {
         const newJson = await Promise.all(
             chains.map(async (chain, index) => {
                 await chain.createAPI();
-
-                return {
-                    ...jsonChains[index],
-                    specName: chain.api?.runtimeVersion.specName.toString(),
-                };
+                const specName = chain.api?.runtimeVersion.specName.toString();
+        
+                return specName
+                    ? { ...jsonChains[index], specName }
+                    : { ...jsonChains[index] };
             })
         );
 

--- a/scripts/buildChainsJson.js
+++ b/scripts/buildChainsJson.js
@@ -28,7 +28,7 @@ const TYPE_EXTRAS_REPLACEMENTS = [
 ]
 const STAKING_ALLOWED_ARRAY = ['Polkadot', 'Kusama', 'Westend', 'Polkadex', 'Ternoa', 'Novasama Testnet - Kusama']
 
-const DEFAULT_ASSETS = ['SHIBATALES', 'DEV', 'SIRI', 'PILT', 'cDOT-6/13', 'cDOT-7/14', 'cDOT-8/15', 'cDOT-9/16', 'cDOT-10/17', 'TZERO', 'UNIT', 'Unit', 'tEDG'];
+const DEFAULT_ASSETS = ['SHIBATALES', 'DEV', 'SIRI', 'PILT', 'cDOT-6/13', 'cDOT-7/14', 'cDOT-8/15', 'cDOT-9/16', 'cDOT-10/17', 'TZERO', 'UNIT', 'Unit', 'tEDG','JOE', 'HOP'];
 
 const readmeContent = fs.readFileSync('chains/v1/README.md', 'utf8');
 const multisigSection = readmeContent.split('# List of Networks where we are support Multisig pallet')[1].split('## The list of supported networks')[0];
@@ -153,7 +153,8 @@ function replaceUrl(url, type, name = undefined) {
       const tickerNames = [name, name.split("-")[0], TICKER_NAMES[name]];
       const relativePath = findFileByTicker(tickerNames, ASSET_ICONS_DIR);
       if (!relativePath) {
-        throw new Error(`Can't find file for: ${name} in: ${ASSET_ICONS_DIR}`);
+        console.error(`Can't find file for: ${name} in: ${ASSET_ICONS_DIR}`);
+        return changedBaseUrl.replace(/\/icons\/.*/, `/${TICKER_NAMES[name]}`);
       }
 
       return changedBaseUrl.replace(/\/icons\/.*/, `/${relativePath}`);

--- a/scripts/checkChainsConfig.js
+++ b/scripts/checkChainsConfig.js
@@ -5,6 +5,7 @@ const path = require('path');
 const BASE_ICON_PATH = "/nova-spektr-utils/main/icons/"
 const KNOWN_EXPLORERS = [
     'Subscan',
+    'SCAN',
     'Polkascan',
     'Polkaholic',
     'Sub.ID',

--- a/scripts/checkChainsConfig.js
+++ b/scripts/checkChainsConfig.js
@@ -35,6 +35,16 @@ function checkBlockExplorers(chainsJSON) {
     });
 }
 
+function checkSpecNames(chainsJSON) {
+    const errors = [];
+    chainsJSON.forEach(chain => {
+        if (!chain.specName) {
+            errors.push(`Chain "${chain.name}" is missing specName`);
+        }
+    });
+    return errors;
+}
+
 let hasError = false;
 function checkChainsFile(filePath) {
     let chainsFile = fs.readFileSync(filePath);
@@ -42,6 +52,12 @@ function checkChainsFile(filePath) {
 
     // check that new explorers were not added
     checkBlockExplorers(chainsJSON)
+    const specNameErrors = checkSpecNames(chainsJSON);
+    if (specNameErrors.length > 0) {
+        console.error(`Errors in file ${filePath}:`);
+        specNameErrors.forEach(error => console.error(error));
+        hasError = true;
+    }
 
     let allIcons = jp.query(chainsJSON, "$..icon");
     let relativeIcons = [];

--- a/scripts/data/assetsNameMap.json
+++ b/scripts/data/assetsNameMap.json
@@ -150,5 +150,12 @@
   "KREST": "KREST token",
   "JUR": "Jur token",
   "MANTA": "Manta token",
-  "ENJ": "Enjin token"
+  "ENJ": "Enjin token",
+  "JOE": "JOE token",
+  "DAI-Karura": "DAI-Karura",
+  "USDC-Karura": "USDC-Karura",
+  "HOP": "HOP token",
+  "VT": "VT token",
+  "WATR": "WATR token",
+  "JOY": "Joystream"
 }


### PR DESCRIPTION
That PR:
- fixes network generation script it will generate even if some icons is missed.
- fix createApi in Chain class, there is a bug, when we try to connect only for the first node
- fix specName script in order only update specName and not delete if we can't receive it from the chain
- Update from v16 nova-utils version
- Remove redundant test networks
