### PR TITLE
fix: update rpc node for mythos

### DIFF
--- a/chains/v1/chains.json
+++ b/chains/v1/chains.json
@@ -6207,7 +6207,7 @@
         ],
         "nodes": [
             {
-                "url": "wss://polkadot-mythos-rpc.polkadot.io",
+                "url": "wss://mythos-rpc.dmarket.com",
                 "name": "Parity node"
             }
         ],

--- a/chains/v1/chains_dev.json
+++ b/chains/v1/chains_dev.json
@@ -6460,7 +6460,7 @@
         ],
         "nodes": [
             {
-                "url": "wss://polkadot-mythos-rpc.polkadot.io",
+                "url": "wss://mythos-rpc.dmarket.com",
                 "name": "Parity node"
             }
         ],

--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -5117,7 +5117,7 @@
         ],
         "nodes": [
             {
-                "url": "wss://polkadot-mythos-rpc.polkadot.io",
+                "url": "wss://mythos-rpc.dmarket.com",
                 "name": "Parity node"
             }
         ],

--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -5336,7 +5336,7 @@
         ],
         "nodes": [
             {
-                "url": "wss://polkadot-mythos-rpc.polkadot.io",
+                "url": "wss://mythos-rpc.dmarket.com",
                 "name": "Parity node"
             }
         ],


### PR DESCRIPTION
Update Mythos RPC node URL from polkadot-mythos-rpc.polkadot.io to mythos-rpc.dmarket.com across all chain configs.