### PR TITLE
feat: add Westend Asset Hub to prod config

### DIFF
--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -348,6 +348,104 @@
         }
     },
     {
+        "name": "Westend Asset Hub (TESTNET)",
+        "specName": "westend",
+        "addressPrefix": 42,
+        "chainId": "0x67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9",
+        "parentId": "0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e",
+        "icon": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v1/chains/Westend_Testnet.svg",
+        "options": [
+            "testnet",
+            "multisig",
+            "pure_proxy",
+            "regular_proxy",
+            "vested_transfer",
+            "multi_transfer"
+        ],
+        "nodes": [
+            {
+                "url": "wss://asset-hub-westend-rpc.dwellir.com",
+                "name": "Dwellir"
+            },
+            {
+                "url": "wss://westmint-rpc-tn.dwellir.com",
+                "name": "Dwellir Tunisia"
+            },
+            {
+                "url": "wss://sys.ibp.network/asset-hub-westend",
+                "name": "IBP1"
+            },
+            {
+                "url": "wss://asset-hub-westend.dotters.network",
+                "name": "IBP2"
+            },
+            {
+                "url": "wss://westend-asset-hub-rpc.polkadot.io",
+                "name": "Parity"
+            },
+            {
+                "url": "wss://asset-hub-westend.rpc.permanence.io",
+                "name": "Permanence DAO EU"
+            },
+            {
+                "url": "wss://asset-hub-westend-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            }
+        ],
+        "assets": [
+            {
+                "name": "Westend",
+                "assetId": 0,
+                "symbol": "WND",
+                "precision": 12,
+                "type": "native",
+                "staking": "relaychain",
+                "icon": {
+                    "monochrome": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v2/assets/monochrome/WND.svg",
+                    "colored": "https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/icons/v2/assets/colored/WND.svg"
+                }
+            }
+        ],
+        "explorers": [
+            {
+                "name": "Subscan",
+                "extrinsic": "https://assethub-westend.subscan.io/extrinsic/{hash}",
+                "account": "https://assethub-westend.subscan.io/account/{address}",
+                "multisig": "https://assethub-westend.subscan.io/multisig_extrinsic/{index}?call_hash={callHash}"
+            },
+            {
+                "name": "Statescan",
+                "account": "https://assethub-westend.statescan.io/#/accounts/{address}",
+                "extrinsic": "https://assethub-westend.statescan.io/#/extrinsics/{hash}",
+                "event": "https://assethub-westend.statescan.io/#/events/{event}"
+            }
+        ],
+        "externalApi": {
+            "staking": [
+                {
+                    "type": "subquery",
+                    "url": "https://subquery-history-westend-ah-prod.novasama-tech.org"
+                }
+            ],
+            "history": [
+                {
+                    "type": "subquery",
+                    "url": "https://subquery-history-westend-ah-prod.novasama-tech.org"
+                }
+            ],
+            "proxy": [
+                {
+                    "type": "subquery",
+                    "url": "https://subquery-accounts-prod-2.novasama-tech.org"
+                }
+            ]
+        },
+        "additional": {
+            "timelineChain": "0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e",
+            "supportsGenericLedgerApp": true
+        }
+    },
+    {
         "name": "Kusama Asset Hub",
         "specName": "kusama",
         "addressPrefix": 2,

--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -436,7 +436,7 @@
             "proxy": [
                 {
                     "type": "subquery",
-                    "url": "https://subquery-accounts-prod-2.novasama-tech.org"
+                    "url": "https://subquery-accounts-prod.novasama-tech.org"
                 }
             ]
         },

--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -446,7 +446,7 @@
             "proxy": [
                 {
                     "type": "subquery",
-                    "url": "https://subquery-accounts-prod-2.novasama-tech.org"
+                    "url": "https://subquery-accounts-prod.novasama-tech.org"
                 }
             ]
         },

--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -446,7 +446,7 @@
             "proxy": [
                 {
                     "type": "subquery",
-                    "url": "https://subquery-accounts-prod.novasama-tech.org"
+                    "url": "https://subquery-accounts-prod-2.novasama-tech.org"
                 }
             ]
         },


### PR DESCRIPTION
## Summary

Returns Westend to the app after the Asset Hub Migration: WND balances, staking and multisig now live on Westend Asset Hub, so the prod config needs a WAH entry (the existing relay entry has no staking asset since the AHM).

- **chains.json**: add `Westend Asset Hub (TESTNET)` (copied from the dev config) with:
  - `staking: relaychain` on WND + `additional.timelineChain` → Westend relay (era duration is derived from relay Babe consts)
  - history/staking indexer → `subquery-history-westend-ah-prod.novasama-tech.org` (deployed, fully synced)
  - proxy indexer → `subquery-accounts-prod-2.novasama-tech.org` — the `westend-ah` indexer on prod-1 (`subquery-accounts-prod`) has been stalled for ~6 months (ArgoCD app `sub-indexer-accounts-westend-ah-prod` is OutOfSync, its statefulset is gone), prod-2 is fully synced
  - no `governance` option for now — there is no prod governance indexer for westend-ah (staging only)
- **chains_dev.json**: switch the WAH proxy indexer to prod-2 for the same reason

## Testing

Paired with a nova-spektr PR that temporarily points `CHAINS_CONFIG_URL` at this branch.